### PR TITLE
Migrate to use iceperf agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# go-relay-perf-com-tests
-relayperf.com golang tests
+# ICEPerf-Agent
+
+This is the component of ICEPerf that runs the tests against each of the TURN networks and projects

--- a/acceptance-tests/get_ice_servers_test.go
+++ b/acceptance-tests/get_ice_servers_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/cloudflare"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/expressturn"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/metered"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/twilio"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/xirsys"
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
-	"github.com/nimbleape/go-relay-perf-com-tests/specifications"
+	"github.com/nimbleape/iceperf-agent/adapters/cloudflare"
+	"github.com/nimbleape/iceperf-agent/adapters/expressturn"
+	"github.com/nimbleape/iceperf-agent/adapters/metered"
+	"github.com/nimbleape/iceperf-agent/adapters/twilio"
+	"github.com/nimbleape/iceperf-agent/adapters/xirsys"
+	"github.com/nimbleape/iceperf-agent/config"
+	"github.com/nimbleape/iceperf-agent/specifications"
 )
 
 func TestMeteredICEServers(t *testing.T) {

--- a/acceptance-tests/server_connect_test.go
+++ b/acceptance-tests/server_connect_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/joho/godotenv"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/serverconnect"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/webrtcpeerconnect"
-	"github.com/nimbleape/go-relay-perf-com-tests/specifications"
+	"github.com/nimbleape/iceperf-agent/adapters/serverconnect"
+	"github.com/nimbleape/iceperf-agent/adapters/webrtcpeerconnect"
+	"github.com/nimbleape/iceperf-agent/specifications"
 	"github.com/pion/webrtc/v4"
 )
 

--- a/adapters/cloudflare/driver.go
+++ b/adapters/cloudflare/driver.go
@@ -3,7 +3,7 @@ package cloudflare
 import (
 	"fmt"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
+	"github.com/nimbleape/iceperf-agent/config"
 	"github.com/pion/webrtc/v4"
 )
 

--- a/adapters/elixir/driver.go
+++ b/adapters/elixir/driver.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
+	"github.com/nimbleape/iceperf-agent/config"
 	"github.com/pion/stun/v2"
 	"github.com/pion/webrtc/v4"
 	log "github.com/sirupsen/logrus"

--- a/adapters/expressturn/driver.go
+++ b/adapters/expressturn/driver.go
@@ -3,7 +3,7 @@ package expressturn
 import (
 	"fmt"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
+	"github.com/nimbleape/iceperf-agent/config"
 	"github.com/pion/webrtc/v4"
 )
 

--- a/adapters/google/driver.go
+++ b/adapters/google/driver.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
+	"github.com/nimbleape/iceperf-agent/config"
 	"github.com/pion/webrtc/v4"
 )
 

--- a/adapters/metered/driver.go
+++ b/adapters/metered/driver.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
+	"github.com/nimbleape/iceperf-agent/config"
 	"github.com/pion/stun/v2"
 	"github.com/pion/webrtc/v4"
 	log "github.com/sirupsen/logrus"

--- a/adapters/twilio/driver.go
+++ b/adapters/twilio/driver.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
+	"github.com/nimbleape/iceperf-agent/config"
 	"github.com/pion/stun/v2"
 	"github.com/pion/webrtc/v4"
 	log "github.com/sirupsen/logrus"

--- a/adapters/xirsys/driver.go
+++ b/adapters/xirsys/driver.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
+	"github.com/nimbleape/iceperf-agent/config"
 	"github.com/pion/stun/v2"
 	"github.com/pion/webrtc/v4"
 	log "github.com/sirupsen/logrus"

--- a/client/client.go
+++ b/client/client.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
-	"github.com/nimbleape/go-relay-perf-com-tests/util"
+	"github.com/nimbleape/iceperf-agent/config"
+	"github.com/nimbleape/iceperf-agent/util"
 	"github.com/pion/stun/v2"
 	"github.com/pion/webrtc/v4"
 	log "github.com/sirupsen/logrus"

--- a/client/dataChannel.go
+++ b/client/dataChannel.go
@@ -5,8 +5,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
-	"github.com/nimbleape/go-relay-perf-com-tests/util"
+	"github.com/nimbleape/iceperf-agent/config"
+	"github.com/nimbleape/iceperf-agent/util"
 	"github.com/pion/stun/v2"
 	"github.com/pion/webrtc/v4"
 	log "github.com/sirupsen/logrus"

--- a/client/ice-servers.go
+++ b/client/ice-servers.go
@@ -1,14 +1,14 @@
 package client
 
 import (
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/cloudflare"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/elixir"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/expressturn"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/google"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/metered"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/twilio"
-	"github.com/nimbleape/go-relay-perf-com-tests/adapters/xirsys"
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
+	"github.com/nimbleape/iceperf-agent/adapters/cloudflare"
+	"github.com/nimbleape/iceperf-agent/adapters/elixir"
+	"github.com/nimbleape/iceperf-agent/adapters/expressturn"
+	"github.com/nimbleape/iceperf-agent/adapters/google"
+	"github.com/nimbleape/iceperf-agent/adapters/metered"
+	"github.com/nimbleape/iceperf-agent/adapters/twilio"
+	"github.com/nimbleape/iceperf-agent/adapters/xirsys"
+	"github.com/nimbleape/iceperf-agent/config"
 	"github.com/pion/webrtc/v4"
 	log "github.com/sirupsen/logrus"
 )

--- a/cmd/iceperf/main.go
+++ b/cmd/iceperf/main.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/nimbleape/go-relay-perf-com-tests/client"
-	"github.com/nimbleape/go-relay-perf-com-tests/config"
-	"github.com/nimbleape/go-relay-perf-com-tests/version"
+	"github.com/nimbleape/iceperf-agent/client"
+	"github.com/nimbleape/iceperf-agent/config"
+	"github.com/nimbleape/iceperf-agent/version"
 	"github.com/pion/stun/v2"
 	"github.com/pion/webrtc/v4"
 	"github.com/rs/xid"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nimbleape/go-relay-perf-com-tests
+module github.com/nimbleape/iceperf-agent
 
 go 1.21.6
 


### PR DESCRIPTION
We should have moved the paths to iceperf-agent github url