### PR TITLE
Added turn_to_turn config option

### DIFF
--- a/adapters/cloudflare/driver.go
+++ b/adapters/cloudflare/driver.go
@@ -35,6 +35,7 @@ func (d *Driver) GetIceServers() (adapters.IceServersConfig, error) {
 	iceServers := adapters.IceServersConfig{
 		IceServers:   []webrtc.ICEServer{},
 		DoThroughput: d.Config.DoThroughput,
+		TurnToTurn:   d.Config.TurnToTurn,
 	}
 
 	if d.Config.RequestUrl != "" {

--- a/adapters/types.go
+++ b/adapters/types.go
@@ -5,4 +5,5 @@ import "github.com/pion/webrtc/v4"
 type IceServersConfig struct {
 	IceServers   []webrtc.ICEServer
 	DoThroughput bool
+	TurnToTurn   bool
 }

--- a/client/client.go
+++ b/client/client.go
@@ -41,11 +41,11 @@ type Client struct {
 	config            *config.Config
 }
 
-func NewClient(config *config.Config, iceServerInfo *stun.URI, provider string, testRunId xid.ID, testRunStartedAt time.Time, doThroughputTest bool, close chan struct{}) (c *Client, err error) {
-	return newClient(config, iceServerInfo, provider, testRunId, testRunStartedAt, doThroughputTest, close)
+func NewClient(config *config.Config, iceServerInfo *stun.URI, provider string, testRunId xid.ID, testRunStartedAt time.Time, doThroughputTest bool, doTurnToTurn bool, close chan struct{}) (c *Client, err error) {
+	return newClient(config, iceServerInfo, provider, testRunId, testRunStartedAt, doThroughputTest, doTurnToTurn, close)
 }
 
-func newClient(cc *config.Config, iceServerInfo *stun.URI, provider string, testRunId xid.ID, testRunStartedAt time.Time, doThroughputTest bool, close chan struct{}) (*Client, error) {
+func newClient(cc *config.Config, iceServerInfo *stun.URI, provider string, testRunId xid.ID, testRunStartedAt time.Time, doThroughputTest bool, doTurnToTurn bool, close chan struct{}) (*Client, error) {
 
 	// Start timers
 	startTime = time.Now()
@@ -58,7 +58,7 @@ func newClient(cc *config.Config, iceServerInfo *stun.URI, provider string, test
 	stats.SetPort(fmt.Sprintf("%d", iceServerInfo.Port))
 	stats.SetNode(cc.NodeID)
 
-	connectionPair, err := newConnectionPair(cc, iceServerInfo, provider, stats, doThroughputTest, close)
+	connectionPair, err := newConnectionPair(cc, iceServerInfo, provider, stats, doThroughputTest, doTurnToTurn, close)
 
 	if doThroughputTest {
 		bufferedAmountLowThreshold = 4 * 1024 * 1024 // 4 Mib

--- a/cmd/iceperf/main.go
+++ b/cmd/iceperf/main.go
@@ -295,7 +295,7 @@ func runTest(logg *slog.Logger, config *config.Config) error {
 			timer := time.NewTimer(testDuration)
 			close := make(chan struct{})
 
-			c, err := client.NewClient(config, iceServerInfo, provider, testRunId, testRunStartedAt, iss.DoThroughput, close)
+			c, err := client.NewClient(config, iceServerInfo, provider, testRunId, testRunStartedAt, iss.DoThroughput, iss.TurnToTurn, close)
 			if err != nil {
 				return err
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type ICEConfig struct {
 	StunEnabled  bool             `yaml:"stun_enabled"`
 	TurnEnabled  bool             `yaml:"turn_enabled"`
 	DoThroughput bool             `yaml:"do_throughput"`
+	TurnToTurn   bool             `yaml:"turn_to_turn"`
 }
 
 type LokiConfig struct {


### PR DESCRIPTION
This PR adds a new config option so that both PeerConnection use TURN servers only. Enabling the option results teh communication path going from a triable into a trapezoid.