### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.5-bullseye AS builder
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /app
 
@@ -8,17 +8,13 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o /iceperf-agent cmd/iceperf/main.go
+RUN CGO_ENABLED=0 ldflags="-s -w" go build -o /iceperf-agent cmd/iceperf/main.go
 
-FROM debian:bullseye-slim
+FROM gcr.io/distroless/static
 
 WORKDIR /
 
-RUN apt-get update && apt-get install -y ca-certificates
-
 COPY --from=builder /iceperf-agent .
-
-RUN ls -lsa /
 
 ENTRYPOINT ["./iceperf-agent"]
 CMD ["-h"]


### PR DESCRIPTION
Hi guys,
Iceperf is an excellent project, and I want to make it work with the [STUNner](https://github.com/l7mp/stunner) K8s media gateway. As I passed through the codebase, I found this low-hanging fruit. So, this PR reduces the docker image size from 122 MB to 22 MB.
The tricks used:
- build a static binary and strip the debug info
- use a smaller [runner base image](https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md)
