### PR TITLE
Make generic servers using password auth work

### DIFF
--- a/client/ice-servers.go
+++ b/client/ice-servers.go
@@ -23,13 +23,16 @@ func formGenericIceServers(config *config.ICEConfig) (adapters.IceServersConfig,
 	iceServers := []webrtc.ICEServer{}
 	if config.StunEnabled {
 		for proto, ports := range config.StunPorts {
+			query := ""
+			if !config.StunUseRFC7094URI {
+				query = fmt.Sprintf("?transport=%s", proto)
+			}
 			for _, port := range ports {
 				stunProto := "stun"
 				if proto == "tls" {
 					stunProto = "stuns"
 				}
-				url := fmt.Sprintf("%s:%s:%d?transport=%s",
-					stunProto, config.StunHost, port, proto)
+				url := fmt.Sprintf("%s:%s:%d%s", stunProto, config.StunHost, port, query)
 
 				iceServers = append(iceServers,
 					webrtc.ICEServer{

--- a/client/ice-servers.go
+++ b/client/ice-servers.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/nimbleape/iceperf-agent/adapters"
@@ -19,7 +20,55 @@ import (
 )
 
 func formGenericIceServers(config *config.ICEConfig) (adapters.IceServersConfig, error) {
-	return adapters.IceServersConfig{}, nil
+	iceServers := []webrtc.ICEServer{}
+	if config.StunEnabled {
+		for proto, ports := range config.StunPorts {
+			for _, port := range ports {
+				stunProto := "stun"
+				if proto == "tls" {
+					stunProto = "stuns"
+				}
+				url := fmt.Sprintf("%s:%s:%d?transport=%s",
+					stunProto, config.StunHost, port, proto)
+
+				iceServers = append(iceServers,
+					webrtc.ICEServer{
+						URLs:           []string{url},
+						Username:       config.Username,
+						Credential:     config.Password,
+						CredentialType: webrtc.ICECredentialTypePassword,
+					})
+
+			}
+		}
+	}
+	if config.TurnEnabled {
+		for proto, ports := range config.TurnPorts {
+			for _, port := range ports {
+				turnProto := "turn"
+				if proto == "tls" {
+					turnProto = "turns"
+				}
+				url := fmt.Sprintf("%s:%s:%d?transport=%s",
+					turnProto, config.TurnHost, port, proto)
+
+				iceServers = append(iceServers,
+					webrtc.ICEServer{
+						URLs:           []string{url},
+						Username:       config.Username,
+						Credential:     config.Password,
+						CredentialType: webrtc.ICECredentialTypePassword,
+					})
+			}
+		}
+
+	}
+	c := adapters.IceServersConfig{
+		IceServers:   iceServers,
+		DoThroughput: config.DoThroughput,
+	}
+
+	return c, nil
 }
 
 type IceServersConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -14,21 +14,22 @@ import (
 )
 
 type ICEConfig struct {
-	Username     string           `yaml:"username,omitempty"`
-	Password     string           `yaml:"password,omitempty"`
-	ApiKey       string           `json:"apiKey,omitempty" yaml:"api_key,omitempty"`
-	AccountSid   string           `yaml:"account_sid,omitempty"`
-	RequestUrl   string           `json:"requestUrl,omitempty" yaml:"request_url,omitempty"`
-	HttpUsername string           `yaml:"http_username"`
-	HttpPassword string           `yaml:"http_password"`
-	Enabled      bool             `yaml:"enabled"`
-	StunHost     string           `yaml:"stun_host,omitempty"`
-	TurnHost     string           `yaml:"turn_host,omitempty"`
-	TurnPorts    map[string][]int `yaml:"turn_ports,omitempty"`
-	StunPorts    map[string][]int `yaml:"stun_ports,omitempty"`
-	StunEnabled  bool             `yaml:"stun_enabled"`
-	TurnEnabled  bool             `yaml:"turn_enabled"`
-	DoThroughput bool             `yaml:"do_throughput"`
+	Username          string           `yaml:"username,omitempty"`
+	Password          string           `yaml:"password,omitempty"`
+	ApiKey            string           `json:"apiKey,omitempty" yaml:"api_key,omitempty"`
+	AccountSid        string           `yaml:"account_sid,omitempty"`
+	RequestUrl        string           `json:"requestUrl,omitempty" yaml:"request_url,omitempty"`
+	HttpUsername      string           `yaml:"http_username"`
+	HttpPassword      string           `yaml:"http_password"`
+	Enabled           bool             `yaml:"enabled"`
+	StunUseRFC7094URI bool             `yaml:"stun_use_rfc7094_uri"`
+	StunHost          string           `yaml:"stun_host,omitempty"`
+	TurnHost          string           `yaml:"turn_host,omitempty"`
+	TurnPorts         map[string][]int `yaml:"turn_ports,omitempty"`
+	StunPorts         map[string][]int `yaml:"stun_ports,omitempty"`
+	StunEnabled       bool             `yaml:"stun_enabled"`
+	TurnEnabled       bool             `yaml:"turn_enabled"`
+	DoThroughput      bool             `yaml:"do_throughput"`
 }
 
 type LokiConfig struct {


### PR DESCRIPTION
Hi,

I wanted to test iceperf-agent against a TURN server on loopback.
So, I started the pion/turn server example:
```shell
PION_LOG_DEBUG=all go run examples/turn-server/simple/main.go -public-ip 127.0.0.1 -users "user=pass"`
```
I made this iceperf config:
```yaml
node_id:  1
timer:
  enabled: false
logging:
  level: info
ice_servers:
  pionturn:
    enabled: true
    stun_enabled: false
    turn_enabled: true
    do_throughput: false
    username: "user"
    password: "pass"
    stun_host: 127.0.0.1
    stun_ports:
      udp:
        - 3478
    turn_host: 127.0.0.1
    turn_ports:
      udp:
        - 3478
```

---

Iceperf was skipping testing the TURN server (see the empty IceServers list):
```
$ ./iceperf-agent -c config-localhost.yaml
time=2024-09-16T15:56:58.549+02:00 level=INFO msg="default IceServers" testRunId=crk3ianfe56e1i3ka5l0 key=pionturn is="{IceServers:[] DoThroughput:false}"
time=2024-09-16T15:56:58.549+02:00 level=INFO msg="Provider Starting" testRunId=crk3ianfe56e1i3ka5l0 Provider=pionturn
time=2024-09-16T15:56:58.549+02:00 level=INFO msg="Provider Finished" testRunId=crk3ianfe56e1i3ka5l0 Provider=pionturn
time=2024-09-16T15:56:58.549+02:00 level=INFO msg="Finished Test Run" testRunId=crk3ianfe56e1i3ka5l0
Provider  Scheme  Protocol  Time to candidate  Max Throughput  TURN Transfer Latency
```

After applying this PR, it seems working:
```
$ ./iceperf-agent -c config-localhost.yaml
time=2024-09-16T16:00:33.858+02:00 level=INFO msg="default IceServers" testRunId=crk3k0ffe56fj19tk240 key=pionturn is="{IceServers:[{URLs:[turn:127.0.0.1:3478?transport=udp] Username:user Credential:pass CredentialType:password}] DoThroughput:false}"
time=2024-09-16T16:00:33.858+02:00 level=INFO msg="Provider Starting" testRunId=crk3k0ffe56fj19tk240 Provider=pionturn
time=2024-09-16T16:00:33.858+02:00 level=INFO msg="URL is" testRunId=crk3k0ffe56fj19tk240 Provider=pionturn url="{URLs:[turn:127.0.0.1:3478?transport=udp] Username:user Credential:pass CredentialType:password}"
time=2024-09-16T16:00:33.858+02:00 level=INFO msg="Starting New Client" testRunId=crk3k0ffe56fj19tk240 Provider=pionturn iceServerTestRunId=crk3k0ffe56fj19tk24g schemeAndProtocol=turn-udp iceServerHost=127.0.0.1 iceServerProtocol=udp iceServerPort=3478 iceServerScheme=turn
[...]
time=2024-09-16T16:00:36.953+02:00 level=INFO msg="{\"testRunID\":\"crk3k0ffe56fj19tk240\",\"labels\":null,\"answererTimeToReceiveCandidate\":77,\"offererTimeToReceiveCandidate\":7,\"offererDcBytesSentTotal\":249856,\"offererIceTransportBytesSentTotal\":269054,\"offererIceTransportBytesReceivedTotal\":10611,\"answererDcBytesReceivedTotal\":0,\"answererIceTransportBytesReceivedTotal\":0,\"answererIceTransportBytesSentTotal\":0,\"latencyFirstPacket\":1,\"throughput\":{},\"instantThroughput\":{},\"throughputMax\":0,\"testRunStartedAt\":\"2024-09-16T16:00:33.858034183+02:00\",\"provider\":\"pionturn\",\"scheme\":\"turn\",\"protocol\":\"udp\",\"port\":\"3478\",\"node\":\"1\",\"timeToConnectedState\":2089,\"connected\":true}" testRunId=crk3k0ffe56fj19tk240 Provider=pionturn iceServerTestRunId=crk3k0ffe56fj19tk24g schemeAndProtocol=turn-udp individual_test_completed=true
time=2024-09-16T16:00:36.954+02:00 level=INFO msg="Peer Connection State has changed" testRunId=crk3k0ffe56fj19tk240 Provider=pionturn iceServerTestRunId=crk3k0ffe56fj19tk24g schemeAndProtocol=turn-udp peer=Answerer eventTime=2024-09-16T16:00:36.954+02:00 peerConnState=closed
time=2024-09-16T16:00:36.954+02:00 level=INFO msg="Answerer connection closed" testRunId=crk3k0ffe56fj19tk240 Provider=pionturn iceServerTestRunId=crk3k0ffe56fj19tk24g schemeAndProtocol=turn-udp peer=Answerer eventTime=2024-09-16T16:00:36.954+02:00 timeSinceStartMs=3095
time=2024-09-16T16:00:37.050+02:00 level=INFO msg="On ticker: Calculated throughput" testRunId=crk3k0ffe56fj19tk240 Provider=pionturn iceServerTestRunId=crk3k0ffe56fj19tk24g schemeAndProtocol=turn-udp peer=Answerer throughput=0.014197414428853092 eventTime=2024-09-16T16:00:37.050+02:00 timeSinceStartMs=1100
time=2024-09-16T16:00:37.953+02:00 level=INFO msg=Finished testRunId=crk3k0ffe56fj19tk240 Provider=pionturn iceServerTestRunId=crk3k0ffe56fj19tk24g schemeAndProtocol=turn-udp
time=2024-09-16T16:00:37.953+02:00 level=INFO msg="Provider Finished" testRunId=crk3k0ffe56fj19tk240 Provider=pionturn
time=2024-09-16T16:00:37.953+02:00 level=INFO msg="Finished Test Run" testRunId=crk3k0ffe56fj19tk240
Provider  Scheme  Protocol  Time to candidate  Max Throughput  TURN Transfer Latency  
pionturn   turn    udp       7                  0               1   
```