### PR TITLE
Create an option to run a DNS query before the STUN/TURN tests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -48,15 +48,6 @@ func NewClient(config *config.Config, iceServerInfo *stun.URI, provider string, 
 
 func newClient(cc *config.Config, iceServerInfo *stun.URI, provider string, testRunId xid.ID, testRunStartedAt time.Time, doThroughputTest bool, close chan struct{}) (*Client, error) {
 
-	// Perform a DNS query to cache the DNS if config is set
-	if cc.ICEConfig[provider].DNSQueryEnabled {
-		dnsQueryDuration, err := performDNSQuery(iceServerInfo.Host)
-		if err != nil {
-			return nil, err
-		}
-		cc.Logger.Info("DNS query completed", "dnsQueryDuration", dnsQueryDuration)
-	}
-
 	// Start timers
 	startTime = time.Now()
 
@@ -306,7 +297,7 @@ func (c *Client) Stop() error {
 // Run a simple DNS query and return the duration and error
 // This function will make sure that the DNS is cached and subsequent
 // STUN and TURN sessions are not affected by the DNS query time
-func performDNSQuery(hostname string) (time.Duration, error) {
+func PerformDNSQuery(hostname string) (time.Duration, error) {
     start := time.Now()
     _, err := net.LookupIP(hostname)
     duration := time.Since(start)

--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -46,6 +47,15 @@ func NewClient(config *config.Config, iceServerInfo *stun.URI, provider string, 
 }
 
 func newClient(cc *config.Config, iceServerInfo *stun.URI, provider string, testRunId xid.ID, testRunStartedAt time.Time, doThroughputTest bool, close chan struct{}) (*Client, error) {
+
+	// Perform a DNS query to cache the DNS if config is set
+	if cc.ICEConfig[provider].DNSQueryEnabled {
+		dnsQueryDuration, err := performDNSQuery(iceServerInfo.Host)
+		if err != nil {
+			return nil, err
+		}
+		cc.Logger.Info("DNS query completed", "dnsQueryDuration", dnsQueryDuration)
+	}
 
 	// Start timers
 	startTime = time.Now()
@@ -291,4 +301,14 @@ func (c *Client) Stop() error {
 	c.Logger.Info(j, "individual_test_completed", "true")
 
 	return nil
+}
+
+// Run a simple DNS query and return the duration and error
+// This function will make sure that the DNS is cached and subsequent
+// STUN and TURN sessions are not affected by the DNS query time
+func performDNSQuery(hostname string) (time.Duration, error) {
+    start := time.Now()
+    _, err := net.LookupIP(hostname)
+    duration := time.Since(start)
+    return duration, err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type ICEConfig struct {
 	StunEnabled       bool             `yaml:"stun_enabled"`
 	TurnEnabled       bool             `yaml:"turn_enabled"`
 	DoThroughput      bool             `yaml:"do_throughput"`
+	DNSQueryEnabled   bool             `yaml:"dns_query_enabled,omitempty"`
 }
 
 type LokiConfig struct {


### PR DESCRIPTION
### This PR adds support to run a DNS query before the actual STUN and TURN measurements are started to measure DNS query time and cache the IP of the STUN/TURN server

I noticed during my tests that sometimes the STUN latency measurement gives a quite high result comapred to the RTT between the client and the server. I double check our STUN server ([using this tool](https://github.com/renandincer/stun-timing)) and I figured out that this is not caused by the server itself, but actually the DNS query time of our domain is a bit slow. 

The other intresting fact is that this DNS query time usually only affects the first measurement (tipically STUN latency) and the subsequent tests to the same server (e.g. TURN tests) will have the domain cached locally (e.g. due to `systemd-resolved`) so they don't contain this extra step.

Therefore, I figured that I add a new option to `iceperf-agent` which can run a DNS query befor starting the actual STUN/TURN tests to populate the DNS cache. It works as follows:
 - there is a new option in the config called `dns_query_enabled` on the provider config which can be set to `true` to trigger this behaviour
  - if the option is set to `false` or omitted, the separate DNS query won't be executed, maintining backward compatibility with old config files
   - the result of the DNS query is also printed out after the test as follows (you can see that only the first DNS query took a long time, subsequent DNS queries are fast due to local cache):
 ```
Provider  Scheme  Protocol  Time to candidate  Max Throughput  TURN Transfer Latency
stunner   stun    dns       24                 0               0
stunner   stun    udp       22                 0               0
stunner   turn    dns       4                  0               0
stunner   turn    udp       38                 0               16
 ```
 
Note: I'm not sure if this is the proper output format (e.g. `scheme=stun, protocol=dns` does not make too much sense, but this way we can see which measurement the DNS query belonged to). Let me know if I should change the output format.
 
PS: It's also fair to say that the DNS query is also part of the ICE process, so it make sense to include this in the actual STUN/TURN measurements (e.g. if you have a slow DNS service then the whole ICE process will be slowed down), but seperating the DNS from the actual STUN/TURN measurement can also point the user to which part of the system is actually causing the delay (like in my case).